### PR TITLE
Leaderboard add guild description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,40 @@ git clone https://github.com/Luna-devv/mellow-web
 
 Create a `.env` file and add the following values:
 ```env
-NEXT_PUBLIC_CAPTCHA_ID=
-NEXT_PUBLIC_LANG_API="https://i18n.wamellow.com/v0"
-NEXT_PUBLIC_API="https://api.wamellow.com/v1"
+NEXT_PUBLIC_CAPTCHA_ID=""
+NEXT_PUBLIC_API="https://api.local.wamellow.com/v1"
 NEXT_PUBLIC_NEKOSTIC="https://nekostic.wamellow.com/statistics"
-NEXT_PUBLIC_LOGIN="https://discord.com/oauth2/authorize?client_id=1125449347451068437&redirect_uri=https://wamellow.com/login&response_type=code"
-API_SECRET=
-NEXT_PUBLIC_BASE_URL="https://wamellow.com"
+NEXT_PUBLIC_LOGIN="https://discord.com/oauth2/authorize?client_id=1116414956972290119&redirect_uri=https://local.wamellow.com/login&response_type=code&permissions=1426738113654&prompt=none&scope=identify+email+guilds"
+NEXT_PUBLIC_BASE_URL="https://local.wamellow.com"
+
+API_SECRET="a"
+
+PLAUSIBLE_API="https://analytics.wamellow.com/api"
+PLAUSIBLE_DOMAIN="wamellow.com"
+PLAUSIBLE_API_KEY=""
+
+RATINGS_API="http://100.65.0.1:5002"
+CLIENT_ID="1125449347451068437"
+
+DISCORD_TOKEN=""
 ```
-For the `NEXT_PUBLIC_CAPTCHA_ID` register a https://www.geetest.com/en/ account, this is used for /passport's. For the `API_SECRET` hack my computer to get access to the backend API and it's secrets. (dun't duh)
+For the `NEXT_PUBLIC_CAPTCHA_ID` register a https://www.geetest.com/en/ account, this is used for /passport's.
+For the `API_SECRET` hack my computer to get access to the backend API and it's secrets. (dun't duh)
+For the `PLAUSIBE_*` stuff you have to either create or selfhost https://plausible.com/
+For the `RATINGS_API` enter a ip/domain to a ratings api duh, read the typings for a structure.
+For the `CLIENT_ID` enter your Discord client id.
+For the `DISCORD_TOKEN` go on repl.it and find a random repo that leaks the token and use it.
 
 ## Deploy
+The bun package manager is cool, the runtime sucks imo tho, you can also use pnpm.
 
 To run the develoment server run
 ```bash
-pnpm dev
+bun dev
 ```
 
 To build and run the website use
 ```bash
-pnpm build
-pnpm start
+bun build
+bun start
 ```

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -316,7 +316,7 @@ export default async function Home() {
                             <h3 className={styles.h3}>Free /image command</h3>
                             <div className="pt-6">
                                 Summon the enchantment of AI-generated images to your Discord server with our versatile /image command, featuring over 40 distinct custom models.
-                                Elevate your server to a haven for unique and dynamic AI-generated images, ensuring a delightful experience for all enthusiasts of the digital arts.
+                                Customize the rating, quality, aesthetics, image width and height, upscaled, generation steps and the CFG scale all for free.
                             </div>
                             <div className="p-4 pb-3 border dark:border-wamellow-alpha border-wamellow-100 rounded-lg my-8">
                                 <Chip

--- a/app/leaderboard/[guildId]/open-graph.png/route.tsx
+++ b/app/leaderboard/[guildId]/open-graph.png/route.tsx
@@ -46,8 +46,13 @@ export async function GET(
                         {truncate(guildExists ? guild.name : "unknown", 19)}
                     </div>
                 </div>
-                <div tw="text-4xl text-gray-500 mb-42" style={{ fontWeight: 500 }}>Explore the vibrant community dynamics</div>
 
+                <div tw="text-3xl text-gray-500 mb-42" style={{ fontWeight: 500 }}>
+                    {guildExists && guild?.description
+                        ? guild.description
+                        : "Explore the vibrant community dynamics"
+                    }
+                </div>
 
                 {Array.isArray(members) &&
                     <div tw="flex justify-between">

--- a/app/leaderboard/[guildId]/page.tsx
+++ b/app/leaderboard/[guildId]/page.tsx
@@ -139,8 +139,11 @@ export default async function Home({ params, searchParams }: Props) {
                         </div>
 
                         <div className="ml-auto flex text-xl font-medium dark:text-neutral-200 text-neutral-800">
-                            <span className="mr-1">
-                                {searchParams.type === "voiceminutes" ? member.activity?.formattedVoicetime : intl.format(member.activity?.[searchParams.type || "messages"])}
+                            <span className="mr-1 break-keep">
+                                {searchParams.type === "voiceminutes"
+                                    ? member.activity?.formattedVoicetime
+                                    : intl.format(member.activity?.[searchParams.type || "messages"])
+                                }
                             </span>
 
                             <Icon type={searchParams.type} />

--- a/app/leaderboard/[guildId]/side.component.tsx
+++ b/app/leaderboard/[guildId]/side.component.tsx
@@ -116,25 +116,19 @@ export default function Side({
                     undefined as unknown as JSX.Element
                 }
 
-                <AccordionItem
-                    key="2"
-                    aria-label="how this works"
-                    title="How this works"
-                    classNames={{ content: "mb-2" }}
-                >
-                    Users are sorted from most to least active for each category, updates once per minute.
-                    <br />
-                    <br />
-                    The percentage {currentCircular !== "server" ? "indicates the gap in messages needed to surpass the next user" : "reflects the contribution of server activity from that user"}.
-                </AccordionItem>
-
                 {pagination && "messages" in pagination ?
                     <AccordionItem
                         key="3"
-                        aria-label="server activity"
-                        title="Server activity"
+                        aria-label="about this server"
+                        title={`About ${guild && "name" in guild ? guild?.name : "this server"}`}
                         classNames={{ content: "mb-2" }}
                     >
+                        {guild && "description" in guild && guild?.description &&
+                            <p className="mb-6">
+                                {guild.description}
+                            </p>
+                        }
+
                         <div className="flex items-center gap-1">
                             <HiAnnotation className="mr-1" />
                             <span className="font-semibold">{intl.format(pagination.messages.total)}</span> messages
@@ -150,6 +144,18 @@ export default function Side({
                     </AccordionItem>
                     : undefined as unknown as JSX.Element
                 }
+
+                <AccordionItem
+                    key="2"
+                    aria-label="how this works"
+                    title="How this works"
+                    classNames={{ content: "mb-2" }}
+                >
+                    Users are sorted from most to least active for each category, updates once per minute.
+                    <br />
+                    <br />
+                    The percentage {currentCircular !== "server" ? "indicates the gap in messages needed to surpass the next user" : "reflects the contribution of server activity from that user"}.
+                </AccordionItem>
 
                 {guild && "id" in guild && guild?.inviteUrl ?
                     <AccordionItem

--- a/typings.ts
+++ b/typings.ts
@@ -36,6 +36,7 @@ export interface ApiV1GuildsGetResponse {
     memberCount: number;
     premiumTier: number;
     inviteUrl: string | undefined;
+    description: string | null;
     follownewsChannel?: {
         id?: string;
         name?: string;


### PR DESCRIPTION
Adds a guilds description set in Discord to the leaderboard page and open graph image.

![image](https://github.com/Luna-devv/mellow-web/assets/71079641/2cd7223f-cd0c-434c-bd3a-4062b5d537c4)

Related issues:
- #13 