### PR TITLE
fix(input/image-url): useless save on load

### DIFF
--- a/components/inputs/image-url-input.tsx
+++ b/components/inputs/image-url-input.tsx
@@ -45,7 +45,8 @@ export function InputImageUrl({
         state,
         error,
         update,
-        save
+        save,
+        isDirty
     } = useInput({
         endpoint,
         k,
@@ -100,13 +101,12 @@ export function InputImageUrl({
 
     const handleImageLoad = () => {
         setImageState(ImageState.Success);
-        // Image loaded successfully, now save
+        if (!isDirty) return;
         void save();
     };
 
     const handleImageError = () => {
         setImageState(ImageState.Errored);
-        // Don't save - image failed to load
     };
 
     const isDisabled = state === InputState.Loading || disabled;


### PR DESCRIPTION
Prevent unnecessary save() calls in image-url-input when the input value hasn't changed (is not dirty), eliminating a wasted API call on initial mount or when the saved value matches the current input.