### PR TITLE
refactor(stats): remove node usage

### DIFF
--- a/app/(home)/status/api.ts
+++ b/app/(home)/status/api.ts
@@ -15,7 +15,6 @@ export interface ApiNode {
     id: string;
     uptime: string;
     memory: number;
-    usage: number;
     players: number;
 }
 

--- a/app/(home)/status/node.component.tsx
+++ b/app/(home)/status/node.component.tsx
@@ -27,9 +27,6 @@ export function Node({ index, node }: { index: number; node: ApiNode; }) {
                 <Row name="memory">
                     {node.memory}mb
                 </Row>
-                <Row name="usage">
-                    {node.usage}%
-                </Row>
                 <Row name="streams">
                     {node.players}
                 </Row>


### PR DESCRIPTION
node stats was removed from the wamellow api when migrating from lavalink to linkdave. Linkdave does not provide node cpu stats