### PR TITLE
fix(premium): hide manage sub on auth failure

### DIFF
--- a/app/(home)/premium/subscribe.component.tsx
+++ b/app/(home)/premium/subscribe.component.tsx
@@ -19,7 +19,7 @@ const PERIODS = ["month", "year"] as const;
 export function Subscribe({ header }: { header?: boolean; }) {
     const search = useSearchParams();
 
-    const premium = userStore((u) => u?.premium !== 0);
+    const premium = userStore((user) => user?.premium && user.premium > 0);
     const [donation, setDonation] = useState(0);
     const [period, setPeriod] = useState<"month" | "year">("month");
 


### PR DESCRIPTION
Fix: hide 'Manage Subscription' button when user is not authenticated or premium is falsy/null — old code mistakenly treated undefined premium as premium user