### PR TITLE
fix(login): open redirect

### DIFF
--- a/app/login/route.ts
+++ b/app/login/route.ts
@@ -113,7 +113,7 @@ function parseRedirectUrlFromState(state: string | null) {
     if (!state) return "/";
 
     const path = decodeURIComponent(state);
-    if (path.includes("://")) return "/";
+    if (!path.startsWith("/") || path.startsWith("//")) return "/";
 
     return path || "/";
 }


### PR DESCRIPTION
Replaces the open-redirect check with a stricter one: blocks any path not starting with "/" (catches absolute URLs like "https://evil.com") and paths starting with "//" (catches protocol-relative URLs like "//evil.com", which the old check missed). No issues found.