### PR TITLE
fix(login): preserve callback query params

### DIFF
--- a/app/dashboard/[guildId]/layout.tsx
+++ b/app/dashboard/[guildId]/layout.tsx
@@ -13,9 +13,9 @@ import { intl } from "@/utils/numbers";
 import { useQuery } from "@tanstack/react-query";
 import Head from "next/head";
 import Link from "next/link";
-import { redirect, useParams } from "next/navigation";
+import { redirect, useParams, usePathname } from "next/navigation";
 import { useCookies } from "next-client-cookies";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { HiBell, HiChartBar, HiChevronLeft, HiCode, HiEye, HiHome, HiPaperAirplane, HiStar, HiUserAdd, HiUsers, HiViewGridAdd } from "react-icons/hi";
 
 import { PremiumReminder } from "./premium-reminder.component";
@@ -57,14 +57,18 @@ export default function RootLayout({
     children: React.ReactNode;
 }) {
     const cookies = useCookies();
+    const session = cookies.get("session");
+    const pathname = usePathname();
     const params = useParams();
+
+    if (!session) {
+        const url = new URL("/login", process.env.NEXT_PUBLIC_BASE_URL);
+        url.searchParams.set("callback", `${pathname}${params.toString() ? `?${params.toString()}` : ""}`);
+        redirect(url.toString());
+    }
 
     const guild = guildStore();
     const user = userStore();
-
-    const session = useMemo(() => cookies.get("session"), [cookies]);
-
-    if (!session) redirect(`/login?callback=/dashboard/${params.guildId}`);
 
     const url = `/guilds/${params.guildId}` as const;
 

--- a/app/dashboard/[guildId]/layout.tsx
+++ b/app/dashboard/[guildId]/layout.tsx
@@ -13,7 +13,7 @@ import { intl } from "@/utils/numbers";
 import { useQuery } from "@tanstack/react-query";
 import Head from "next/head";
 import Link from "next/link";
-import { redirect, useParams, usePathname } from "next/navigation";
+import { redirect, useParams, usePathname, useSearchParams } from "next/navigation";
 import { useCookies } from "next-client-cookies";
 import { useEffect, useRef } from "react";
 import { HiBell, HiChartBar, HiChevronLeft, HiCode, HiEye, HiHome, HiPaperAirplane, HiStar, HiUserAdd, HiUsers, HiViewGridAdd } from "react-icons/hi";
@@ -59,14 +59,15 @@ export default function RootLayout({
     const cookies = useCookies();
     const session = cookies.get("session");
     const pathname = usePathname();
-    const params = useParams();
+    const search = useSearchParams();
 
     if (!session) {
         const url = new URL("/login", process.env.NEXT_PUBLIC_BASE_URL);
-        url.searchParams.set("callback", `${pathname}${params.toString() ? `?${params.toString()}` : ""}`);
+        url.searchParams.set("callback", `${pathname}${search.toString() ? `?${search.toString()}` : ""}`);
         redirect(url.toString());
     }
 
+    const params = useParams();
     const guild = guildStore();
     const user = userStore();
 

--- a/app/login/route.ts
+++ b/app/login/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const jar = await cookies();
 
-    const logout = searchParams.get("logout");
+    const logout = Boolean(searchParams.get("logout"));
 
     if (logout) {
         jar.set(
@@ -51,13 +51,13 @@ export async function GET(request: Request) {
         redirect("/");
     }
 
-    const guildId = searchParams.get("guild_id");
-    const invite = Boolean(searchParams.get("invite"));
     const code = searchParams.get("code");
 
     if (!code) {
-        const callback = searchParams.get("callback");
+        const invite = Boolean(searchParams.get("invite"));
+        const callback = decodeURIComponent(searchParams.get("callback") || "");
         const lastpage = jar.get("lastpage");
+        const guildId = searchParams.get("guild_id");
 
         const url = generateOauthUrl(invite, callback || lastpage?.value, guildId);
         redirect(url);
@@ -93,7 +93,7 @@ function generateOauthUrl(invite: boolean, redirectUrl: string | undefined, guil
     params.append("response_type", "code");
     params.append("state", encodeURIComponent(redirectUrl || "/"));
 
-    if (invite) params.append("scope", "identify guilds bot");
+    if (invite) params.append("scope", "identify guilds email bot");
     else params.append("scope", "identify guilds email");
 
     if (guildId) params.append("guild_id", guildId);
@@ -105,7 +105,11 @@ function getRedirectUrl(searchParams: URLSearchParams) {
     const redirectUrl = parseRedirectUrlFromState(searchParams.get("state"));
     const guildId = searchParams.get("guild_id");
 
-    if (guildId) return `/dashboard/${guildId}${redirectUrl}`;
+    if (guildId) {
+        if (redirectUrl.startsWith(`/dashboard/${guildId}`)) return redirectUrl;
+        return `/dashboard/${guildId}`;
+    }
+
     return redirectUrl;
 }
 

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useApi } from "@/lib/api/hook";
 import type { ApiV1UsersMeGetResponse } from "@/typings";
 import Link from "next/link";
-import { redirect } from "next/navigation";
+import { redirect, usePathname, useSearchParams } from "next/navigation";
 import { useCookies } from "next-client-cookies";
 import CountUp from "react-countup";
 import { HiCreditCard, HiCubeTransparent, HiFire, HiHome, HiPhotograph, HiTranslate } from "react-icons/hi";
@@ -22,8 +22,14 @@ export default function RootLayout({
 }) {
     const cookies = useCookies();
     const session = cookies.get("session");
+    const pathname = usePathname();
+    const params = useSearchParams();
 
-    if (!session) redirect("/login?callback=/profile");
+    if (!session) {
+        const url = new URL("/login", process.env.NEXT_PUBLIC_BASE_URL);
+        url.searchParams.set("callback", `${pathname}${params.toString() ? `?${params.toString()}` : ""}`);
+        redirect(url.toString());
+    }
 
     const user = userStore((u) => u);
     const { data, error } = useApi<ApiV1UsersMeGetResponse>("/users/@me");
@@ -73,7 +79,7 @@ export default function RootLayout({
                             :
                             <div className="flex flex-col mt-2">
                                 <Skeleton className="rounded-xl w-32 h-5 mb-2" />
-                                <Skeleton className="rounded-md w-[90px] h-7" />
+                                <Skeleton className="rounded-md w-22.5 h-7" />
                             </div>
                         }
                     </div>

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -23,11 +23,11 @@ export default function RootLayout({
     const cookies = useCookies();
     const session = cookies.get("session");
     const pathname = usePathname();
-    const params = useSearchParams();
+    const search = useSearchParams();
 
     if (!session) {
         const url = new URL("/login", process.env.NEXT_PUBLIC_BASE_URL);
-        url.searchParams.set("callback", `${pathname}${params.toString() ? `?${params.toString()}` : ""}`);
+        url.searchParams.set("callback", `${pathname}${search.toString() ? `?${search.toString()}` : ""}`);
         redirect(url.toString());
     }
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -201,13 +201,24 @@ function Guild({
 }
 
 function InviteButton({ guildId }: { guildId: string; }) {
+    const url = new URL("/login", process.env.NEXT_PUBLIC_BASE_URL);
+
+    url.searchParams.set("invite", "true");
+    url.searchParams.set("guild_id", guildId);
+
+    const searchParams = useSearchParams();
+    const to = searchParams.get("to");
+    const callback = to ? `/dashboard/${guildId}/${to}` : null;
+
+    if (callback) url.searchParams.set("callback", callback);
+
     return (
         <Button
             asChild
             className="h-8"
         >
             <Link
-                href={`/login?invite=true&guild_id=${guildId}`}
+                href={url.toString()}
                 prefetch={false}
             >
                 <HiUserAdd />


### PR DESCRIPTION
## Before
unauthed -> `/profile?to=notifications` -> oauth2 -> `/profile`
unauthed -> `/dashboard/123/starboard` -> oauth2 -> `/dashboard/123`
authed -> `/profile?to=notifications` -> invite oauth2 -> `/dashboard/123`

## After
unauthed -> `/profile?to=notifications` -> oauth2 -> `/profile?to=notifications`
unauthed -> `/dashboard/123/starboard` -> oauth2 -> `/dashboard/123/starboard`
authed -> `/profile?to=notifications` -> invite oauth2 -> `/dashboard/123/notifications`